### PR TITLE
fix(kubernetes): replace invalid initContainer with proper sidecar co…

### DIFF
--- a/DAY55/Task-55-WebserverSidecarPod.md
+++ b/DAY55/Task-55-WebserverSidecarPod.md
@@ -60,8 +60,10 @@ spec:
       volumeMounts:
         - name: shared-logs
           mountPath: /var/log/nginx
+  initContainers:
     - name: sidecar-container
       image: ubuntu:latest
+      restartPolicy: Always
       command: ["sh", "-c", "while true; do cat /var/log/nginx/access.log /var/log/nginx/error.log; sleep 30; done"]
       volumeMounts:
         - name: shared-logs
@@ -292,8 +294,10 @@ spec:
       volumeMounts:
         - name: shared-logs
           mountPath: /var/log/nginx
+  initContainers:
     - name: sidecar-container
       image: ubuntu:latest
+      restartPolicy: Always
       command: ["sh", "-c", "while true; do cat /var/log/nginx/access.log /var/log/nginx/error.log; sleep 30; done"]
       volumeMounts:
         - name: shared-logs


### PR DESCRIPTION
…ntainer for nginx log aggregation

Fix Sidecar container implementation in webserver Pod

- Corrected Sidecar pattern according to Kubernetes documentation: https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/

- Moved sidecar-container from containers to initContainers 

- Added restartPolicy: Always to ensure continuous execution of the sidecar process